### PR TITLE
[한글 테스트 데이터 생성기]1️⃣. CLIP10. 데이터베이스: DB를 표현할 entity 코드의 작성Feature/12 entity

### DIFF
--- a/src/main/java/com/seol/koreantestdatagenerator/config/JpaConfig.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/config/JpaConfig.java
@@ -13,6 +13,6 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("come");
+        return () -> Optional.of("com");
     }
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/domain/AuditingFields.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/domain/AuditingFields.java
@@ -1,0 +1,41 @@
+package com.seol.koreantestdatagenerator.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; //생성 일시
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    private String createdBy; //생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; //수정 일시
+
+    @LastModifiedBy
+    @Column(nullable = false)
+    private String modifiedBy; //수정자
+
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/domain/MockData.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/domain/MockData.java
@@ -1,16 +1,82 @@
 package com.seol.koreantestdatagenerator.domain;
 
 import com.seol.koreantestdatagenerator.domain.constant.MockDataType;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.Objects;
+
+/**
+ * 특정 {@link MockDataType}에 대응하는 가짜 데이터.
+ * 알고리즘으로 생성하지 않는 {@link MockDataType}의 경우, 이 가짜 데이터를 랜덤으로 뽑아 출력한다.
+ *
+ * @author seol
+ */
 @Getter
-@Setter
 @ToString
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"mockDataType", "mockDataValue"})
+})
+@Entity
 public class MockData {
 
-    private MockDataType mockDataType;
-    private String mockDataValue;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @Setter @Column(nullable = false) private MockDataType mockDataType;
+    @Setter @Column(nullable = false) private String mockDataValue;
+
+    protected MockData() {}
+
+    public MockData(MockDataType mockDataType, String mockDataValue){
+        this.mockDataType = mockDataType;
+        this.mockDataValue = mockDataValue;
+    }
+
+    public static MockData of(MockDataType mockDataType, String mockDataValue){
+        return new MockData(mockDataType, mockDataValue);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof MockData that)) return false;
+
+        if(getId() == null) {
+            return Objects.equals(this.getMockDataType(), that.getMockDataType()) &&
+                    Objects.equals(this.getMockDataValue(), that.getMockDataValue());
+        }
+
+        return Objects.equals(this.getId(), that.getId());
+
+      /*  if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        MockData mockData = (MockData) object;
+
+        if (id ==null) {
+            return Objects.equals(mockDataType, mockData.mockDataType) &&
+                    Objects.equals(mockDataValue, mockData.mockDataValue);
+        }
+
+        return Objects.equals(id, mockData.id);*/
+
+      //  return Objects.equals(id, mockData.id) &&
+      //          mockDataType == mockData.mockDataType &&
+     //           Objects.equals(mockDataValue, mockData.mockDataValue);
+    }
+
+    @Override
+    public int hashCode() {
+
+        if (id == null) {
+            return Objects.hash(mockDataType, mockDataValue);
+        }
+
+        return Objects.hash(id);
+
+        //return Objects.hash(id, mockDataType, mockDataValue);
+    }
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/domain/SchemaField.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/domain/SchemaField.java
@@ -1,20 +1,73 @@
 package com.seol.koreantestdatagenerator.domain;
 
 import com.seol.koreantestdatagenerator.domain.constant.MockDataType;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+
+/**
+ * 특정 {@link TableSchema}의 단위 필드 정보.
+ * 이 필드들이 모여서 테이블 스키마를 구성한다.
+ *
+ * @author seol
+ */
 @Getter
-@Setter
-@ToString
-public class SchemaField {
+@ToString(callSuper = true)
+@Entity
+public class SchemaField extends AuditingFields {
 
-    private String fieldName;
-    private MockDataType mockDataType;
-    private Integer fieldOrder;
-    private Integer blackPercent;
-    private String typeOptionJson;
-    private String foceValue;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @Setter
+    @ManyToOne(optional = false)
+    private TableSchema tableSchema;
+
+    @Setter private @Column(nullable = false) String fieldName;
+    @Setter private @Column(nullable = false) MockDataType mockDataType;
+    @Setter private @Column(nullable = false) Integer fieldOrder;
+    @Setter private @Column(nullable = false) Integer blankPercent;
+
+    @Setter private String typeOptionJson;
+    @Setter private String forceValue;
+
+    protected SchemaField() {}
+
+    public SchemaField(String fieldName, MockDataType mockDataType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue) {
+        this.fieldName = fieldName;
+        this.mockDataType = mockDataType;
+        this.fieldOrder = fieldOrder;
+        this.blankPercent = blankPercent;
+        this.typeOptionJson = typeOptionJson;
+        this.forceValue = forceValue;
+    }
+
+    public static SchemaField of(String fieldName, MockDataType mockDataType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue) {
+        return new SchemaField(fieldName, mockDataType, fieldOrder, blankPercent, typeOptionJson, forceValue);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        SchemaField that = (SchemaField) object;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(fieldName, that.fieldName) &&
+                mockDataType == that.mockDataType &&
+                Objects.equals(fieldOrder, that.fieldOrder) &&
+                Objects.equals(blankPercent, that.blankPercent) &&
+                Objects.equals(typeOptionJson, that.typeOptionJson) &&
+                Objects.equals(forceValue, that.forceValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, fieldName, mockDataType, fieldOrder, blankPercent, typeOptionJson, forceValue);
+    }
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/domain/TableSchema.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/domain/TableSchema.java
@@ -1,18 +1,96 @@
 package com.seol.koreantestdatagenerator.domain;
 
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.*;
 
+/**
+ * 단위 테이블 스키마 정보.
+ * 식별자({@link #userId})로 특정할 수 있는 회원이 소유한다.
+ *
+ * @author seol
+ */
 @Getter
-@Setter
-@ToString
-public class TableSchema {
+@ToString(callSuper = true)
+@Entity
+public class TableSchema extends AuditingFields{
 
-    private String schemaName;
-    private String userId;
-    private LocalDateTime exportedAt;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @Setter private String schemaName;
+    @Setter private String userId;
+    @Setter private LocalDateTime exportedAt;
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "tableSchema", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final Set<SchemaField> schemaFields = new LinkedHashSet<>();
+
+    protected TableSchema() {}
+
+    public TableSchema(String schemaName, String userId) {
+        this.schemaName = schemaName;
+        this.userId = userId;
+        this.exportedAt = null;
+    }
+
+    public static TableSchema of(String schemaName, String userId) {
+        return new TableSchema(schemaName, userId);
+    }
+
+    public void markExported(){
+        exportedAt = LocalDateTime.now();
+    }
+
+    public boolean isExpected(){
+        return exportedAt != null;
+    }
+
+    public void addSchemaField(SchemaField schemaField) {
+        schemaField.setTableSchema(this);
+        schemaFields.add(schemaField);
+    }
+
+    public void addSchemaFields(Collection<SchemaField> schemaFields) {
+        schemaFields.forEach(this::addSchemaField);
+    }
+
+    public void clearSchemaFields() {
+        schemaFields.clear();
+    }
+
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof TableSchema that)) return false;
+
+        if (that.getId() == null) {
+            return Objects.equals(this.getSchemaName(), that.getSchemaName() )&&
+                    Objects.equals(this.getUserId(), that.getUserId()) &&
+                    Objects.equals(this.getExportedAt(), that.getExportedAt()) &&
+                    Objects.equals(this.getSchemaFields(), that.getSchemaFields());
+        }
+
+        return Objects.equals(this.getId(), that.getId());
+
+       // if (object == null || getClass() != object.getClass()) return false;
+       // TableSchema that = (TableSchema) object;
+       // return Objects.equals(id, that.id) && Objects.equals(schemaName, that.schemaName) && Objects.equals(userId, that.userId) && Objects.equals(exportedAt, that.exportedAt) && Objects.equals(schemaFields, that.schemaFields);
+    }
+
+    @Override
+    public int hashCode() {
+        if (getId() == null) {
+            return Objects.hash(this.getSchemaName(), this.getUserId(), this.getExportedAt(), this.getSchemaFields());
+        }
+        return Objects.hash(getId());
+
+        //return Objects.hash(id, schemaName, userId, exportedAt, schemaFields);
+    }
 }


### PR DESCRIPTION
이 작업은 지난 이슈에서 설계했던 도메인들을 JPA entity로 전환하여 실제 DB 테이블에 접근할 수 있는 상태로 만든다.

This closes #14 