### PR TITLE
CLIP15. 필요 기능을 제공할 api와 dto 만들기 2

### DIFF
--- a/src/main/java/com/seol/koreantestdatagenerator/controller/TableSchemaController.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/controller/TableSchemaController.java
@@ -1,0 +1,49 @@
+package com.seol.koreantestdatagenerator.controller;
+
+import com.seol.koreantestdatagenerator.dto.request.TableSchemaRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class TableSchemaController {
+
+    @GetMapping("/table-schema")
+    public String tableSchema(TableSchemaRequest tableSchemaRequest) {
+        return "table-schema";
+    }
+
+    @PostMapping("/table-schema")
+    public String createOrUpdateTableSchema(
+            TableSchemaRequest tableSchemaRequest,
+            RedirectAttributes redirectAttrs
+    ){
+        redirectAttrs.addFlashAttribute("tableSchemaRequest", tableSchemaRequest);
+
+        return "redirect:/table-schema";
+    }
+
+    @GetMapping("/table-schema/my-schemas")
+    public String mySchemas(){
+        return "my-schemas";
+    }
+
+    @PostMapping("/table-schema/my-schemas/{schemaName}")
+    public String deleteMySchema(
+            @PathVariable String schemaName,
+            RedirectAttributes redirectAttrs
+    ){
+        return "redirect:/my-schemas";
+    }
+
+    @GetMapping("/table-schema/export")
+    public ResponseEntity<String> exportTableSchema(TableSchemaRequest tableSchemaRequest) {
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=table-schema.txt")
+                .body("download complete"); //TODO: 나중에 데이터 바꾸기
+    }
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/controller/UserAccountController.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/controller/UserAccountController.java
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
-public class MainController {
+public class UserAccountController {
 
-    @GetMapping("/")
-    public String MainPage(){
-        return "forward:/table-schema";
+    @GetMapping("/my-account")
+    public String myAccount() {
+        return "my-account";
     }
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/dto/request/SchemaFieldRequest.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/dto/request/SchemaFieldRequest.java
@@ -2,35 +2,31 @@ package com.seol.koreantestdatagenerator.dto.request;
 
 import com.seol.koreantestdatagenerator.domain.constant.MockDataType;
 import com.seol.koreantestdatagenerator.dto.SchemaFieldDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public record SchemaFieldRequest(
-        String fieldName,
-        MockDataType mockDataType,
-        Integer fieldOrder,
-        Integer blankPercent,
-        String typeOptionJson,
-        String forceValue
-) {
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+@Data
+public class SchemaFieldRequest{
 
-    public static SchemaFieldRequest of(String fieldName, MockDataType mockDataType, Integer fieldOrder,Integer blankPercent, String typeOptionJson, String forceValue) {
-        return new SchemaFieldRequest(
+    private String fieldName;
+    private MockDataType mockDataType;
+    private Integer fieldOrder;
+    private Integer blankPercent;
+    private String typeOptionJson;
+    private String forceValue;
+
+
+    public SchemaFieldDto toDto() {
+        return SchemaFieldDto.of(
                 fieldName,
                 mockDataType,
                 fieldOrder,
                 blankPercent,
                 typeOptionJson,
-                forceValue);
-    }
-
-
-    public SchemaFieldDto toDto() {
-        return SchemaFieldDto.of(
-                fieldName(),
-                mockDataType(),
-                fieldOrder(),
-                blankPercent(),
-                typeOptionJson(),
-                forceValue()
+                forceValue
         );
     }
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/dto/request/TableSchemaRequest.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/dto/request/TableSchemaRequest.java
@@ -1,24 +1,24 @@
 package com.seol.koreantestdatagenerator.dto.request;
 
 import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import lombok.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record TableSchemaRequest(
-        String schemaName,
-        String userId,
-        List<SchemaFieldRequest> schemaFields
-) {
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+@Data
+public class TableSchemaRequest {
 
-    public static TableSchemaRequest of(String schemaName, String userId, List<SchemaFieldRequest> schemaFields) {
-        return new TableSchemaRequest(schemaName, userId, schemaFields);
-    }
+    private String schemaName;
+    private String userId;
+    private List<SchemaFieldRequest> schemaFields;
 
     public TableSchemaDto toDto() {
         return TableSchemaDto.of(
-                schemaName(),
-                userId(),
+                schemaName,
+                userId,
                 null,
                 schemaFields.stream()
                         .map(SchemaFieldRequest::toDto)

--- a/src/main/resources/templates/my-account.html
+++ b/src/main/resources/templates/my-account.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>내 정보 페이지</title>
+</head>
+<body>
+내 정보 page
+</body>
+</html>

--- a/src/main/resources/templates/my-schemas.html
+++ b/src/main/resources/templates/my-schemas.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>내 테이블 스키마 목록</title>
+</head>
+<body>
+내 테이블 스키마 목록 page
+</body>
+</html>

--- a/src/main/resources/templates/table-schema.html
+++ b/src/main/resources/templates/table-schema.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>테이블 스키마</title>
+</head>
+<body>
+테이블 스키마 페이지
+</body>
+</html>

--- a/src/test/java/com/seol/koreantestdatagenerator/controller/MainControllerTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/controller/MainControllerTest.java
@@ -27,9 +27,7 @@ record MainControllerTest(
         //When & Then
         mvc.perform(get("/"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("index"));
-               // .andDo(print());
+                .andExpect(forwardedUrl("/table-schema"));
     }
 
 }

--- a/src/test/java/com/seol/koreantestdatagenerator/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/controller/TableSchemaControllerTest.java
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Disabled("테스트 우선 작성함. 테스트로 스펙을 전달하고, 아직 구현이 없으므로 비활성화 프로젝트 #19")
+//@Disabled("테스트 우선 작성함. 테스트로 스펙을 전달하고, 아직 구현이 없으므로 비활성화 프로젝트 #19")
 @DisplayName("[Controller] 테이블 스키마 컨트롤러 테스트")
 @Import({SecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest
@@ -65,6 +65,7 @@ record TableSchemaControllerTest(
                         .with(csrf())
                 )
                 .andExpect(status().is3xxRedirection())
+                .andExpect(flash().attribute("tableSchemaRequest", request))
                 .andExpect(redirectedUrl("/table-schema"));
 
     }
@@ -75,7 +76,7 @@ record TableSchemaControllerTest(
         //Given
 
         //When & Then
-        mvc.perform(get("table-schema/my-schemas"))
+        mvc.perform(get("/table-schema/my-schemas"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("my-schemas"));

--- a/src/test/java/com/seol/koreantestdatagenerator/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/controller/UserAccountControllerTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Disabled("테스트 우선 작성함. 테스트로 스펙을 전달하고, 아직 구현이 없으므로 비활성화 프로젝트 #19")
+//@Disabled("테스트 우선 작성함. 테스트로 스펙을 전달하고, 아직 구현이 없으므로 비활성화 프로젝트 #19")
 @DisplayName("[Controller] 회원 컨트롤러 테스트")
 @Import(SecurityConfig.class)
 @WebMvcTest
@@ -27,7 +27,7 @@ record UserAccountControllerTest(@Autowired MockMvc mvc) {
         //When & Then
         mvc.perform(get("/my-account"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("my-account"));
     }
 }


### PR DESCRIPTION
이 작업은 `SchemaFieldRequest`와 `TableSchemaRequest`를 기존의 `record` 정의에서 일반 클래스로 전환하고, 프로젝트 요구 사항에 맞는 API를 새로 생성 및 구현한 후 이를 검증하는 테스트 코드를 작성하여 완료하였습니다.

This closes #21 
