### PR TITLE
불필요한 자바스크립트 관촬용 로그 삭제

### DIFF
--- a/src/main/resources/templates/table-schema.html
+++ b/src/main/resources/templates/table-schema.html
@@ -133,7 +133,7 @@
     enrollDeleteRowEvent(btn, schemaFieldList);
   });
 
-  schemaFieldList.on('updated', list => { console.log(list.items); resetData(list); });
+  schemaFieldList.on('updated', list => resetData(list));
   document.getElementById('add-row').addEventListener('click', () => {
     schemaFieldList.add({});
     const lastRow = schemaFieldList.items.at(-1).elm


### PR DESCRIPTION
이 코드는 테이블 스키마 페이지의 스키마 필드에
변경이 있을 때마다 매번 로그를 출력함.
개발 중에 관찰용으로 들어간 것 같은데
불필요하므로 삭제처리함