### PR TITLE
[한글 테스트 데이터 생성기] 2️⃣. CLIP08. 로직 구현: 개인 스키마 정보 읽어들이기

### DIFF
--- a/src/main/java/com/seol/koreantestdatagenerator/service/TableSchemaService.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/TableSchemaService.java
@@ -1,0 +1,41 @@
+package com.seol.koreantestdatagenerator.service;
+
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import com.seol.koreantestdatagenerator.repository.TableSchemaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TableSchemaService {
+
+    private final TableSchemaRepository tableSchemaRepository;
+
+
+    @Transactional(readOnly = true)
+    public List<TableSchemaDto> loadMySchemas(String userId) {
+        return loadMySchemas(userId, Pageable.unpaged()).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TableSchemaDto> loadMySchemas(String userId, Pageable pageable) {
+        return tableSchemaRepository.findByUserId(userId, pageable)
+                .map(TableSchemaDto::fromEntity);
+    }
+
+    //단권 조회
+    @Transactional(readOnly = true)
+    public TableSchemaDto loadMySchema(String userId, String schemaName) {
+        return tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)
+                .map(TableSchemaDto::fromEntity)
+                .orElseThrow(() -> new EntityNotFoundException("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName));
+    }
+
+}

--- a/src/test/java/com/seol/koreantestdatagenerator/service/TableSchemaServiceTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/service/TableSchemaServiceTest.java
@@ -1,0 +1,92 @@
+package com.seol.koreantestdatagenerator.service;
+
+import com.seol.koreantestdatagenerator.domain.TableSchema;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import com.seol.koreantestdatagenerator.repository.TableSchemaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Service] 테이블 스키마 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TableSchemaServiceTest {
+
+    @InjectMocks private TableSchemaService sut;
+
+    @Mock private TableSchemaRepository tableSchemaRepository;
+
+
+    @DisplayName("사용자 ID가 주어지면, 테이블 스키마 목록을 반환한다.")
+    @Test
+    void givenUserId_whenLoadingMySchemas_thenReturnsTableSchemaList() {
+        // Given
+        String userId = "userId";
+        given(tableSchemaRepository.findByUserId(userId, Pageable.unpaged())).willReturn(new PageImpl<>(List.of(
+                TableSchema.of("table1", userId),
+                TableSchema.of("table2", userId),
+                TableSchema.of("table3", userId)
+        )));
+
+        // When
+        List<TableSchemaDto> result = sut.loadMySchemas(userId);
+
+        // Then
+        assertThat(result)
+                .hasSize(3)
+                .extracting("schemaName")
+                .containsExactly("table1", "table2", "table3");
+        then(tableSchemaRepository).should().findByUserId(userId, Pageable.unpaged());
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름이 주어지면, 테이블 스키마를 반환한다.")
+    @Test
+    void givenUserIdAndSchemaName_whenLoadingMySchema_thenReturnsTableSchema() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        TableSchema tableSchema = TableSchema.of(schemaName, userId);
+        given(tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)).willReturn(Optional.of(tableSchema));
+
+        // When
+        TableSchemaDto result = sut.loadMySchema(userId, schemaName);
+
+        // Then
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("schemaName", schemaName)
+                .hasFieldOrPropertyWithValue("userId", userId);
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름에 대응하는 테이블 스키마가 없으면, 예외를 던진다.")
+    @Test
+    void givenUserIdAndSchemaName_whenLoadingNonexistentMySchema_thenThrowsException() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        given(tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.loadMySchema(userId, schemaName));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName);
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
+    }
+
+}


### PR DESCRIPTION
이 작업은 회원 스키마 목록 읽기 서비스를 컨트롤러에 연동과 회원 단일 스키마 정보 조회 기능 구현 및 연결을 완료하였다.

This closes #43 and #56 