### PR TITLE
[한글 테스트 데이터 생성기] 2️⃣. CLIP11. 로직 구현: 개인 스키마 정보 삭제하기

### DIFF
--- a/src/main/java/com/seol/koreantestdatagenerator/controller/TableSchemaController.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/controller/TableSchemaController.java
@@ -79,7 +79,12 @@ public class TableSchemaController {
     }
 
     @PostMapping("/table-schema/my-schemas/{schemaName}")
-    public String deleteMySchema(@PathVariable String schemaName) {
+    public String deleteMySchema(
+            @AuthenticationPrincipal GithubUser githubUser,
+            @PathVariable String schemaName
+    ) {
+        tableSchemaService.deleteTableSchema(githubUser.id(), schemaName);
+
         return "redirect:/table-schema/my-schemas";
     }
 

--- a/src/main/java/com/seol/koreantestdatagenerator/service/TableSchemaService.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/TableSchemaService.java
@@ -49,4 +49,8 @@ public class TableSchemaService {
                        () -> tableSchemaRepository.save(dto.createEntity())
                );
     }
+
+    public void deleteTableSchema(String userId, String schemaName) {
+        tableSchemaRepository.deleteByUserIdAndSchemaName(userId, schemaName);
+    }
 }

--- a/src/test/java/com/seol/koreantestdatagenerator/controller/TableSchemaControllerTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/controller/TableSchemaControllerTest.java
@@ -150,6 +150,7 @@ class TableSchemaControllerTest {
         // Given
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         String schemaName = "test_schema";
+        willDoNothing().given(tableSchemaService).deleteTableSchema(githubUser.id(), schemaName);
 
         // When & Then
         mvc.perform(
@@ -159,6 +160,7 @@ class TableSchemaControllerTest {
                 )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/table-schema/my-schemas"));
+        then(tableSchemaService).should().deleteTableSchema(githubUser.id(), schemaName);
     }
 
     @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상)")

--- a/src/test/java/com/seol/koreantestdatagenerator/service/TableSchemaServiceTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/service/TableSchemaServiceTest.java
@@ -20,8 +20,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 
 @DisplayName("[Service] 테이블 스키마 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -124,6 +123,21 @@ class TableSchemaServiceTest {
         //Then
         then(tableSchemaRepository).should().findByUserIdAndSchemaName(dto.userId(), dto.schemaName());
         then(tableSchemaRepository).should().save(dto.createEntity());
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름이 주어지면, 테이블 스키마를 삭제한다.")
+    @Test
+    void givenUserIdAndSchemaName_whenDeleting_thenDeletesTableSchema() {
+        //Given
+        String userId = "userId";
+        String schemaName = "table1";
+        willDoNothing().given(tableSchemaRepository).deleteByUserIdAndSchemaName(userId, schemaName);
+
+        //When
+        sut.deleteTableSchema(userId, schemaName);
+
+        //Then
+        then(tableSchemaRepository).should().deleteByUserIdAndSchemaName(userId, schemaName);
     }
 
 }


### PR DESCRIPTION
이 작업은 개인 스키마 정보 삭제하기 기능을 구현하고 컨트롤러 연동작업을 완료하였다.

This closes #59 