### PR TITLE
[한글 테스트 데이터 생성기] 2️⃣. CLIP12. 로직 구현: 스키마 데이터를 원하는 유형으로 변환하는 기능

### DIFF
--- a/src/main/java/com/seol/koreantestdatagenerator/domain/constant/ExportFileType.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/domain/constant/ExportFileType.java
@@ -3,7 +3,7 @@ package com.seol.koreantestdatagenerator.domain.constant;
 public enum ExportFileType {
     CSV,
     TSV,
-    JSON,
-    SQL_INSERT,
+  //  JSON, //TODO:후에 할 것
+  //  SQL_INSERT, //TODO:후에 할 것
     ;
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/domain/constant/ExportFileType.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/domain/constant/ExportFileType.java
@@ -1,5 +1,9 @@
 package com.seol.koreantestdatagenerator.domain.constant;
 
 public enum ExportFileType {
-    CSV, TSV, JSON, SQL_INSERT;
+    CSV,
+    TSV,
+    JSON,
+    SQL_INSERT,
+    ;
 }

--- a/src/main/java/com/seol/koreantestdatagenerator/service/SchemaExportService.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/SchemaExportService.java
@@ -1,0 +1,27 @@
+package com.seol.koreantestdatagenerator.service;
+
+import com.seol.koreantestdatagenerator.domain.TableSchema;
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import com.seol.koreantestdatagenerator.repository.TableSchemaRepository;
+import com.seol.koreantestdatagenerator.service.exporter.MockDataFileExporterContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SchemaExportService {
+
+    private final MockDataFileExporterContext mockDataFileExporterContext;
+    private final TableSchemaRepository tableSchemaRepository;
+
+    public String export(ExportFileType fileType, TableSchemaDto dto, Integer rowCount) {
+        if (dto.userId() != null) {
+            tableSchemaRepository.findByUserIdAndSchemaName(dto.userId(), dto.schemaName())
+                    .ifPresent(TableSchema::markExported);
+        }
+
+        return mockDataFileExporterContext.export(fileType, dto, rowCount);
+    }
+
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/service/exporter/CSVFileExporter.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/exporter/CSVFileExporter.java
@@ -1,0 +1,18 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CSVFileExporter extends DelimiterBasedFileExporter implements MockDataFileExporter {
+
+    @Override
+    public String getDelimiter() {
+        return ",";
+    }
+
+    @Override
+    public ExportFileType getType() {
+        return ExportFileType.CSV;
+    }
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/service/exporter/DelimiterBasedFileExporter.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/exporter/DelimiterBasedFileExporter.java
@@ -1,0 +1,45 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.dto.SchemaFieldDto;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public abstract class DelimiterBasedFileExporter implements MockDataFileExporter {
+
+    /**
+     * 파일 열 구분자로 사용할 문자열을 반환한다.
+     *
+     * @return 파일 열 구분자
+     */
+    public abstract String getDelimiter();
+
+    @Override
+    public String export(TableSchemaDto dto, Integer rowCount){
+        StringBuilder sb = new StringBuilder();
+
+        //헤더 만들기
+        sb.append(dto.schemaFields().stream()
+                .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                .map(SchemaFieldDto::fieldName)
+                .collect(Collectors.joining(getDelimiter()))
+        );
+        sb.append("\n");
+
+        //데이터 부분
+        IntStream.range(0, rowCount).forEach(i ->{
+            sb.append(dto.schemaFields().stream()
+                    .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                    .map(field -> "가짜-데이터")//TODO: 후에 구현할 것
+                    .map(v -> v == null ? "" : v)
+                    .collect(Collectors.joining(getDelimiter()))
+            );
+            sb.append("\n");
+
+        });
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/service/exporter/MockDataFileExporter.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/exporter/MockDataFileExporter.java
@@ -1,0 +1,28 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+
+/**
+ * 특정 파일 유형( {@link ExportFileType})에 맞는 데이터 출력 인터페이스
+ */
+public interface MockDataFileExporter {
+
+    /**
+     * 구현체가 처리하는 출력 파일 유형을 반환하는 메소드
+     *
+     * @return 이 구현체가 다루는 출력 파일 유형
+     */
+    ExportFileType getType();
+
+    /**
+     *
+     * 파일 형식에 맞는 문자열 데이터를 출력하는 메소드.
+     *
+     * @param dto 출력 데이터의 테이블 스키마 정보
+     * @param rowCount 출력할 데이터 행 수
+     * @return 적절한 파일 형식으로 변환된 문자열 데이터
+     */
+    String export(TableSchemaDto dto, Integer rowCount);
+
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/service/exporter/MockDataFileExporterContext.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/exporter/MockDataFileExporterContext.java
@@ -1,0 +1,27 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class MockDataFileExporterContext {
+
+    public final Map<ExportFileType, MockDataFileExporter> mockDataFileExporterMap;
+
+    public MockDataFileExporterContext(List<MockDataFileExporter> mockDataFileExporters) {
+        this.mockDataFileExporterMap = mockDataFileExporters.stream()
+                .collect(Collectors.toMap(MockDataFileExporter::getType, Function.identity()));
+    }
+
+    public String export(ExportFileType fileType, TableSchemaDto dto, Integer rowCount){
+        MockDataFileExporter fileExporter = mockDataFileExporterMap.get(fileType);
+
+        return fileExporter.export(dto, rowCount);
+    }
+}

--- a/src/main/java/com/seol/koreantestdatagenerator/service/exporter/TSVFileExporter.java
+++ b/src/main/java/com/seol/koreantestdatagenerator/service/exporter/TSVFileExporter.java
@@ -1,0 +1,25 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.dto.SchemaFieldDto;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Component
+public class TSVFileExporter extends DelimiterBasedFileExporter implements MockDataFileExporter {
+
+    @Override
+    public String getDelimiter() {
+        return "\t";
+    }
+
+    @Override
+    public ExportFileType getType() {
+        return ExportFileType.TSV;
+    }
+
+}

--- a/src/test/java/com/seol/koreantestdatagenerator/service/SchemaExportServiceTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/service/SchemaExportServiceTest.java
@@ -1,0 +1,71 @@
+package com.seol.koreantestdatagenerator.service;
+
+import com.seol.koreantestdatagenerator.domain.TableSchema;
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import com.seol.koreantestdatagenerator.repository.TableSchemaRepository;
+import com.seol.koreantestdatagenerator.service.exporter.MockDataFileExporterContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+
+@DisplayName("[Service] 스키마 파일 출력 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class SchemaExportServiceTest {
+
+    @InjectMocks private SchemaExportService sut;
+
+    @Mock private MockDataFileExporterContext mockDataFileExporterContext;
+    @Mock private TableSchemaRepository tableSchemaRepository;
+
+    @DisplayName("출력 파일 유형과 스키마 정보와 행 수가 주어지면, 엔티티 출력 여부를 마킹하고 알맞은 파일 유형으로 가짜 테이터 파일을 반환한다.")
+    @Test
+    void givenFileTypeAndSchemaAndRowCount_whenExporting_thenMarksEntityExportedAndReturnsFileFormattedString() {
+        // Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of("test_schema", "seol", null, null);
+        int rowCount = 5;
+        TableSchema exectedTableSchema = TableSchema.of(dto.schemaName(), dto.userId());
+        given(tableSchemaRepository.findByUserIdAndSchemaName(dto.userId(), dto.schemaName()))
+                .willReturn(Optional.of(exectedTableSchema));
+        given(mockDataFileExporterContext.export(exportFileType, dto, rowCount)).willReturn("test,file,format");
+
+        // When
+        String result = sut.export(exportFileType, dto, rowCount);
+
+        // Then
+        assertThat(result).isEqualTo("test,file,format");
+        assertThat(exectedTableSchema.isExported()).isTrue();
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(dto.userId(), dto.schemaName());
+        then(mockDataFileExporterContext).should().export(exportFileType, dto, rowCount);
+    }
+
+    @DisplayName("입력 파라미터 중에 유저 식별 정보가 없으면, 스키마 테이블 조회를 시도하지 않는다.")
+    @Test
+    void givenNoUserIdInParams_whenExporting_thenDoesNotTrySelectingTableSchema() {
+        // Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of("test_schema", null, null, null);
+        int rowCount = 5;
+        given(mockDataFileExporterContext.export(exportFileType, dto, rowCount)).willReturn("test,file,format");
+
+        // When
+        String result = sut.export(exportFileType, dto, rowCount);
+
+        // Then
+        assertThat(result).isEqualTo("test,file,format");
+        then(tableSchemaRepository).shouldHaveNoInteractions();
+        then(mockDataFileExporterContext).should().export(exportFileType, dto, rowCount);
+    }
+
+}

--- a/src/test/java/com/seol/koreantestdatagenerator/service/exporter/CSVFileExporterTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/service/exporter/CSVFileExporterTest.java
@@ -1,0 +1,47 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.domain.constant.MockDataType;
+import com.seol.koreantestdatagenerator.dto.SchemaFieldDto;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Logic] CSV 파일 출력기 테스트")
+class CSVFileExporterTest {
+
+    private CSVFileExporter sut = new CSVFileExporter();
+
+    @DisplayName("테이블 스키마 정보와 행 수가 주어지면, CSV 형식의 문자열을 생성한다.")
+    @Test
+    void givenSchemaAndRowCount_whenExporting_thenReturnsCSVFormattedString() {
+        //Given
+        TableSchemaDto dto = TableSchemaDto.of(
+                "table_schema",
+                "seol",
+                null,
+                Set.of(
+                        SchemaFieldDto.of("id", MockDataType.ROW_NUMBER, 1, 0, null,null),
+                        SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null,null),
+                        SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null,null),
+                        SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null,null),
+                        SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null,null)
+                )
+        );
+        int rowCount = 10;
+
+        //When
+        String result = sut.export(dto, rowCount);
+
+        //Then
+        System.out.println(result);
+        assertThat(result).startsWith("id,name,age,car,created_at");
+
+    }
+
+}

--- a/src/test/java/com/seol/koreantestdatagenerator/service/exporter/MockDataFileExporterContextTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/service/exporter/MockDataFileExporterContextTest.java
@@ -1,0 +1,52 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.TableSchema;
+import com.seol.koreantestdatagenerator.domain.constant.ExportFileType;
+import com.seol.koreantestdatagenerator.domain.constant.MockDataType;
+import com.seol.koreantestdatagenerator.dto.SchemaFieldDto;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import org.aspectj.apache.bcel.classfile.Module;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DisplayName("[IntegrationTest] 파일 출력기 컨텍스트 테스트")
+@SpringBootTest
+record MockDataFileExporterContextTest(@Autowired MockDataFileExporterContext sut) {
+
+    @DisplayName("파일 형식과 테이블 스키마와 행 수가 주어지면, 파일 형식에 맞게 변환한 문자열을 리턴한다.")
+    @Test
+    void givenFileTypeAndTableSchemaAndRowCount_whenExporting_thenReturnsFileFormattedString() {
+        // Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of(
+                "test_schema",
+                "seol",
+                null,
+                Set.of(
+                        SchemaFieldDto.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
+                        SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null, null),
+                        SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null, null),
+                        SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null, null),
+                        SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null, null)
+                )
+        );
+        int rowCount = 10;
+
+        // When
+        String result = sut.export(exportFileType, dto, rowCount);
+
+        // Then
+        System.out.println(result); // 관찰용
+        assertThat(result).startsWith("id,name,age,car,created_at");
+    }
+
+}

--- a/src/test/java/com/seol/koreantestdatagenerator/service/exporter/TSVFileExporterTest.java
+++ b/src/test/java/com/seol/koreantestdatagenerator/service/exporter/TSVFileExporterTest.java
@@ -1,0 +1,45 @@
+package com.seol.koreantestdatagenerator.service.exporter;
+
+import com.seol.koreantestdatagenerator.domain.constant.MockDataType;
+import com.seol.koreantestdatagenerator.dto.SchemaFieldDto;
+import com.seol.koreantestdatagenerator.dto.TableSchemaDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Logic] TSV 파일 출력하기 테스트")
+class TSVFileExporterTest {
+
+    private TSVFileExporter sut = new TSVFileExporter();
+
+    @DisplayName("테이블 스키마 정보와 행 수가 주어지면, TSV 형식의 문자열을 생성한다.")
+    @Test
+    void givenSchemaAndRowCount_whenExporting_thenReturnsTSVFormattedString() {
+        //Given
+        TableSchemaDto dto = TableSchemaDto.of(
+                "table_schema",
+                "seol",
+                null,
+                Set.of(
+                        SchemaFieldDto.of("id", MockDataType.ROW_NUMBER, 1, 0, null,null),
+                        SchemaFieldDto.of("name", MockDataType.NAME, 2, 0, null,null),
+                        SchemaFieldDto.of("age", MockDataType.NUMBER, 3, 0, null,null),
+                        SchemaFieldDto.of("car", MockDataType.CAR, 4, 0, null,null),
+                        SchemaFieldDto.of("created_at", MockDataType.DATETIME, 5, 0, null,null)
+                )
+        );
+        int rowCount = 10;
+
+        //When
+        String result = sut.export(dto, rowCount);
+
+        //Then
+        System.out.println(result);
+        assertThat(result).startsWith("id\tname\tage\tcar\tcreated_at");
+
+    }
+}


### PR DESCRIPTION
이 작업은 한글 테스트 데이터 생성기의 비즈니스 로직을 구현하고 그 중 개인 스키마 정보를 특정 파일 포맷으로 변환하는 기능을 구현하였다.
(우선순위로 CSV, TSV 먼저 구현, 후에 JSON이랑 SQL 구현 예정)

This closes #60 